### PR TITLE
Pin jsonschame to < 4.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ requirements:
     - websocket-client >=0.35.0
     - boto3 >=1.16.0
     - swagger-spec-validator >=2.7.4
+    - jsonschema < 4.0.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - websocket-client >=0.35.0
     - boto3 >=1.16.0
     - swagger-spec-validator >=2.7.4
-    - jsonschema < 4.0.0
+    - jsonschema <4.0.0
 
 test:
   imports:


### PR DESCRIPTION
bravado-core has invalid regexp for filtering out standard jsonschemas . This causes bravado to attempt downloading the schame, causing neptune-client to fail when working on internet-less environments

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
